### PR TITLE
fix: googletest deprecated version to newer version

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -2,7 +2,7 @@ include(FetchContent)
 FetchContent_Declare(
   googletest
   GIT_REPOSITORY https://github.com/google/googletest.git
-  GIT_TAG        release-1.10.0
+  GIT_TAG        release-1.12.0
 )
 
 FetchContent_MakeAvailable(googletest)


### PR DESCRIPTION
문제: mac m1에서 googletest 1.10.0 버전 에러남
관련 쓰레드: https://github.com/google/googletest/issues/4026
해결법: googletest 1.10.0 -> 1.12.0 버전 업그레이드.


번외: 모두의코드 강의 정말 감사합니다.. 도움 많이 됬어요!